### PR TITLE
Move secrets to server project

### DIFF
--- a/EtherpunkBlazorWasm/Server/AppSettings.cs
+++ b/EtherpunkBlazorWasm/Server/AppSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace EtherpunkBlazorWasm.Shared;
+﻿namespace EtherpunkBlazorWasm.Server;
 public class AppSettings
 {
     public const string ValidAudience = "EpunkAud";

--- a/EtherpunkBlazorWasm/Server/Program.cs
+++ b/EtherpunkBlazorWasm/Server/Program.cs
@@ -1,6 +1,6 @@
+using EtherpunkBlazorWasm.Server;
 using EtherpunkBlazorWasm.Server.Auth;
 using EtherpunkBlazorWasm.Server.Data;
-using EtherpunkBlazorWasm.Shared;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;


### PR DESCRIPTION
The secret and salt shouldn't be sent to clients' machines, it opens up the opportunity to open the dll and extract them, leaking your secrets.